### PR TITLE
要約とネクストアクションを25文字で返すように変更

### DIFF
--- a/functions/src/utils/openai/summarize.ts
+++ b/functions/src/utils/openai/summarize.ts
@@ -1,27 +1,27 @@
-import { CompletionCreateParams, singleCompletion } from "./openai";
+import { singleCompletion } from "./openai";
 
 const systemMessage =
-  "メッセージの内容を箇条書きで要約してください。返信が必要な要件や頼まれている要件がある場合は、その旨を要約に含めてください。送信者の名前やメールアドレス、日付などの情報は要約に含めないでください。";
+  "メッセージの内容を2行の箇条書きで返してください。1行目は要約、2行目は受け取ったメッセージに対して次にすべき行動を返してください。";
 
 const examples = [
   {
     userMessage:
-      "明日の会議は午前10時から始まります。場所は5階の会議室です。資料は事前にメールで送りましたので、確認してください。また、午後のスケジュールが変更になりましたので、カレンダーをチェックしてください。",
-    assistantMessage:
-      "- 明日10時から会議\n- 場所: 5階の会議室\n- 資料はメールで送信済み\n- 午後のスケジュール変更あり\n- タスク\n  - 資料の確認\n  - カレンダーの確認"
+      "明日の会議は午前10時から始まります。場所は5階の会議室です。資料は事前にメールで送りましたので、確認してください。",
+    assistantMessage: "- 明日の会議は10時開始\n- 資料を確認"
   },
   {
     userMessage:
-      "来週の月曜日に新しいプロジェクトのキックオフミーティングが予定されています。時間は午後3時から5時までです。場所はオンラインで、Zoomのリンクは後ほど共有します。事前にプロジェクトの概要を読んでおいてください。また、質問があれば事前にメールで送ってください。",
-    assistantMessage:
-      "- 来週の月曜日にキックオフミーティング\n- 時間: 午後3時から5時\n- 場所: オンライン (Zoomリンクは後ほど)\n- タスク\n  - プロジェクトの概要の確認\n  - 質問があれば事前にメールで送信"
+      "方向性と今後のスケジュール確認のため打ち合わせをお願いできればと存じます。つきましては、下記の日程でご都合のよろしい日時をご連絡いただけますでしょうか。",
+    assistantMessage: "- 打ち合わせのお願い\n- 日程の調整"
   }
 ];
 
-export const summarize = (message: string, params?: CompletionCreateParams) =>
+export const summarize = (message: string) =>
   singleCompletion({
     userMessage: message,
     systemMessage,
     examples,
-    params
+    params: {
+      max_tokens: 25
+    }
   });


### PR DESCRIPTION
<!-- 例えば #100 と書くと Issue 100 へのリンクになります -->
### 関連 Issue
#1 


### 概要
要約とネクストアクションを2行の箇条書きで返すように変更しました。
パラメータとしてmax_tokenを25に設定して、最大で25字で返すようにしました。

<!-- 全て埋める必要はありません. 開発時に使ったものにチェック入れてください. -->
### 動作確認

- [ ] iOS シミュレータ例えば #100 と書くと Issue 100 へのリンクになります -->
### 関連 Issue


### 概要
要約とネクストアクションを2行の箇条書きで返すように変更しました。
パラメータとしてmax_tokenを25に設定して、

<!-- 全て埋める必要はありません. 開発時に使ったものにチェック入れてください. -->
### 動作確認

- [x] iOS シミュレータ
- [ ] Android シミュレータ
- [ ] iOS 実機
- [ ] Android 実機

### Copilot

copilot:all

- [ ] Android シミュレータ
- [ ] iOS 実機
- [ ] Android 実機

### Copilot

copilot:all
